### PR TITLE
Upgrade the version "anothrNick/github-tag-action"

### DIFF
--- a/.github/workflows/build_latex.yml
+++ b/.github/workflows/build_latex.yml
@@ -23,7 +23,7 @@ jobs:
         file ./v2/english/augur-whitepaper-v2.pdf | grep -q ' PDF '
     - name: Bump version and push tag
       id: bump_version
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: anothrNick/github-tag-action@1.39.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true


### PR DESCRIPTION
In order to avoid errors, I upgrade the version of `anothrNick/github-tag-action`  to the latest (@1.39.0).
reference:
https://github.com/anothrNick/github-tag-action/releases