### PR TITLE
Upgrade 3rd-party action & use commit SHA

### DIFF
--- a/.github/workflows/build_latex.yml
+++ b/.github/workflows/build_latex.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e
     - name: Build LaTeX document
-      uses: xu-cheng/latex-action@v2
+      uses: xu-cheng/latex-action@2031f1a94940bfe35904fc1782bf18a9bdafc127
       with:
         root_file: main.tex
         working_directory: v2/english
@@ -23,7 +23,7 @@ jobs:
         file ./v2/english/augur-whitepaper-v2.pdf | grep -q ' PDF '
     - name: Bump version and push tag
       id: bump_version
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: anothrNick/github-tag-action@3840ec22ac98e14d981375e3ae2d8d0392964521
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
@@ -31,7 +31,7 @@ jobs:
         INITIAL_VERSION: 2.0.0
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -41,7 +41,7 @@ jobs:
         prerelease: false
     - name: Upload Release Asset
       id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
To avoid errors, I upgrade the version of [anothrNick/github-tag-action](https://github.com/anothrNick/github-tag-action) to the latest (@1.39.0).
(Cause of errors not investigated and unknown.)

And to avoid trusting tags set by repository authors, I specify a version by commit SHA, not by tag.

The following is a list of repositories and their versions used in YML. 
- actions/checkout
 The version written in the YML: `v2`
 The version actually used: `v2.4.2`
 Link: https://github.com/actions/checkout/releases/tag/v2.4.2

- xu-cheng/latex-action
The version written in the YML: `v2`
The version actually used: `2.5.0`
Link: https://github.com/xu-cheng/latex-action/releases/tag/2.5.0

- anothrNick/github-tag-action
The version actually used : `1.39.0`
Link: https://github.com/anothrNick/github-tag-action/releases/tag/1.39.0


- actions/create-release
The version written in the YML: `v1`
The version actually used: `v1.1.4`
Link: https://github.com/actions/create-release/releases/tag/v1.1.4

- actions/upload-release-asset
The version written in the YML: `v1`
The version actually used: `v1.0.2`
Link: https://github.com/actions/upload-release-asset/releases/tag/v1.0.2