### PR TITLE
Add Ryan Garner to V1 authors

### DIFF
--- a/v1/english/main.tex
+++ b/v1/english/main.tex
@@ -63,9 +63,9 @@
 
 \title{Augur: a Decentralized Oracle and Prediction Market Platform}
 
-\author{Ryan Garner}
 \author{Jack Peterson}
 \author{Joseph Krug}
+\author{Ryan Garner}
 \author{Micah Zoltu}
 \author{Austin K. Williams}
 \author{Stephanie Alexander}

--- a/v1/english/main.tex
+++ b/v1/english/main.tex
@@ -63,6 +63,7 @@
 
 \title{Augur: a Decentralized Oracle and Prediction Market Platform}
 
+\author{Ryan Garner}
 \author{Jack Peterson}
 \author{Joseph Krug}
 \author{Micah Zoltu}


### PR DESCRIPTION
Ryan Garner was the primary architect and author but his name was left off the whitepaper. This branch adds this missing name.